### PR TITLE
R-4.0 compatibility fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: gptk
-Version: 1.08
-Date: 2014-03-07
+Version: 1.09
+Date: 2020-03-02
 Title: Gaussian Processes Tool-Kit
 Author: Alfredo Kalaitzis <alkalait@gmail.com>,
-	Antti Honkela <antti.honkela@tkk.fi>,
+	Antti Honkela <antti.honkela@helsinki.fi>,
 	Pei Gao <pg349@medschl.cam.ac.uk>,
 	Neil D. Lawrence <N.Lawrence@dcs.shef.ac.uk>
 Maintainer: Alfredo Kalaitzis <alkalait@gmail.com>
 Depends: R (>= 2.8.0), Matrix, fields
-Imports: 
+Imports: Biobase, methods
 Suggests: spam
 Description: The gptk package implements a general-purpose toolkit for Gaussian
   process regression with a variety of covariance functions (e.g. RBF, Mattern, polynomial, etc).

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,13 +3,11 @@ importClassesFrom(Biobase, AnnotatedDataFrame, AssayData, eSet, ExpressionSet,
 
 importClassesFrom(methods, character, list, matrix, numeric)
 
-importMethodsFrom(as.list, colnames, exists, get, ncol, revmap, tail)
-
 importMethodsFrom(methods, initialize, show)
 
 importFrom(graphics, layout, lines, par, plot, title)
 
-importFrom(methods, "@<-", callNextMethod, new)
+importFrom(methods, callNextMethod, new)
 
 importFrom(stats, optim, optimize, qgamma, qnorm, rnorm, sd)
 

--- a/R/miscFunctions.R
+++ b/R/miscFunctions.R
@@ -184,7 +184,7 @@ boundedTransform <- function (x, transform="atox", bounds) {
 
   invCh <- try (solve( Ch, eyeM ), silent=TRUE)
 
-  if ( class(invCh) == "try-error" ) {
+  if ( "try-error" %in% class(invCh) ) {
     return (NaN)
   }
   else {


### PR DESCRIPTION
Potentially important compatibility fix for upcoming R-4.0. (Same bug in tigre caused vignette building to run indefinitely.)

I included minimal changes to NAMESPACE to make package check run without errors, but a lot of warnings remain that might be good to tackle.